### PR TITLE
Consolidate dev-tools folder into elasticsearch-parent.

### DIFF
--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -3,6 +3,7 @@
   <groupId>org.elasticsearch</groupId>
   <artifactId>dev-tools</artifactId>
   <version>2.0.0-SNAPSHOT</version>
+  <name>Elasticsearch Build Resources</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -1,0 +1,29 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.elasticsearch</groupId>
+  <artifactId>dev-tools</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <includes>
+            <include>**/*</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -10,6 +10,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <version>1.5</version>
         <executions>

--- a/dev-tools/src/main/resources/forbidden/all-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/all-signatures.txt
@@ -1,0 +1,47 @@
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance  with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on
+# an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+@defaultMessage Convert to URI
+java.net.URL#getPath()
+java.net.URL#getFile()
+
+@defaultMessage Use java.nio.file instead of java.io.File API
+java.util.jar.JarFile
+java.util.zip.ZipFile
+java.io.File
+java.io.FileInputStream
+java.io.FileOutputStream
+java.io.PrintStream#<init>(java.lang.String,java.lang.String)
+java.io.PrintWriter#<init>(java.lang.String,java.lang.String)
+java.util.Formatter#<init>(java.lang.String,java.lang.String,java.util.Locale)
+java.io.RandomAccessFile
+java.nio.file.Path#toFile()
+
+@defaultMessage Don't use deprecated lucene apis
+org.apache.lucene.index.DocsEnum
+org.apache.lucene.index.DocsAndPositionsEnum
+org.apache.lucene.queries.TermFilter
+org.apache.lucene.queries.TermsFilter
+org.apache.lucene.search.TermRangeFilter
+org.apache.lucene.search.NumericRangeFilter
+org.apache.lucene.search.PrefixFilter
+
+java.nio.file.Paths @ Use PathUtils.get instead.
+java.nio.file.FileSystems#getDefault() @ use PathUtils.getDefault instead.
+
+@defaultMessage Specify a location for the temp file/directory instead.
+java.nio.file.Files#createTempDirectory(java.lang.String,java.nio.file.attribute.FileAttribute[])
+java.nio.file.Files#createTempFile(java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute[])

--- a/dev-tools/src/main/resources/forbidden/core-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/core-signatures.txt
@@ -1,0 +1,133 @@
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance  with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on
+# an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+@defaultMessage spawns threads with vague names; use a custom thread factory and name threads so that you can tell (by its name) which executor it is associated with
+
+java.util.concurrent.Executors#newFixedThreadPool(int)
+java.util.concurrent.Executors#newSingleThreadExecutor()
+java.util.concurrent.Executors#newCachedThreadPool()
+java.util.concurrent.Executors#newSingleThreadScheduledExecutor()
+java.util.concurrent.Executors#newScheduledThreadPool(int)
+java.util.concurrent.Executors#defaultThreadFactory()
+java.util.concurrent.Executors#privilegedThreadFactory()
+
+java.lang.Character#codePointBefore(char[],int) @ Implicit start offset is error-prone when the char[] is a buffer and the first chars are random chars
+java.lang.Character#codePointAt(char[],int) @ Implicit end offset is error-prone when the char[] is a buffer and the last chars are random chars
+
+@defaultMessage Collections.sort dumps data into an array, sorts the array and reinserts data into the list, one should rather use Lucene's CollectionUtil sort methods which sort in place
+
+java.util.Collections#sort(java.util.List)
+java.util.Collections#sort(java.util.List,java.util.Comparator)
+
+java.io.StringReader#<init>(java.lang.String) @ Use FastStringReader instead
+
+@defaultMessage Reference management is tricky, leave it to SearcherManager
+org.apache.lucene.index.IndexReader#decRef()
+org.apache.lucene.index.IndexReader#incRef()
+org.apache.lucene.index.IndexReader#tryIncRef()
+
+@defaultMessage Pass the precision step from the mappings explicitly instead
+org.apache.lucene.search.NumericRangeQuery#newDoubleRange(java.lang.String,java.lang.Double,java.lang.Double,boolean,boolean)
+org.apache.lucene.search.NumericRangeQuery#newFloatRange(java.lang.String,java.lang.Float,java.lang.Float,boolean,boolean)
+org.apache.lucene.search.NumericRangeQuery#newIntRange(java.lang.String,java.lang.Integer,java.lang.Integer,boolean,boolean)
+org.apache.lucene.search.NumericRangeQuery#newLongRange(java.lang.String,java.lang.Long,java.lang.Long,boolean,boolean)
+org.apache.lucene.search.NumericRangeFilter#newDoubleRange(java.lang.String,java.lang.Double,java.lang.Double,boolean,boolean)
+org.apache.lucene.search.NumericRangeFilter#newFloatRange(java.lang.String,java.lang.Float,java.lang.Float,boolean,boolean)
+org.apache.lucene.search.NumericRangeFilter#newIntRange(java.lang.String,java.lang.Integer,java.lang.Integer,boolean,boolean)
+org.apache.lucene.search.NumericRangeFilter#newLongRange(java.lang.String,java.lang.Long,java.lang.Long,boolean,boolean)
+
+@defaultMessage Only use wait / notify when really needed try to use concurrency primitives, latches or callbacks instead. 
+java.lang.Object#wait()
+java.lang.Object#wait(long)
+java.lang.Object#wait(long,int)
+java.lang.Object#notify()
+java.lang.Object#notifyAll()
+
+@defaultMessage Beware of the behavior of this method on MIN_VALUE
+java.lang.Math#abs(int)
+java.lang.Math#abs(long)
+
+@defaultMessage Please do not try to stop the world
+java.lang.System#gc()
+
+@defaultMessage Use Long.compare instead we are on Java7
+com.google.common.primitives.Longs#compare(long,long)
+
+@defaultMessage Use Channels.* methods to write to channels. Do not write directly.
+java.nio.channels.WritableByteChannel#write(java.nio.ByteBuffer)
+java.nio.channels.FileChannel#write(java.nio.ByteBuffer, long)
+java.nio.channels.GatheringByteChannel#write(java.nio.ByteBuffer[], int, int)
+java.nio.channels.GatheringByteChannel#write(java.nio.ByteBuffer[])
+java.nio.channels.ReadableByteChannel#read(java.nio.ByteBuffer)
+java.nio.channels.ScatteringByteChannel#read(java.nio.ByteBuffer[])
+java.nio.channels.ScatteringByteChannel#read(java.nio.ByteBuffer[], int, int)
+java.nio.channels.FileChannel#read(java.nio.ByteBuffer, long)
+
+@defaultMessage Use Lucene.parseLenient instead it strips off minor version
+org.apache.lucene.util.Version#parseLeniently(java.lang.String)
+
+@defaultMessage unsafe encoders/decoders have problems in the lzf compress library.  Use variants of encode/decode functions which take Encoder/Decoder.
+com.ning.compress.lzf.impl.UnsafeChunkEncoders#createEncoder(int)
+com.ning.compress.lzf.impl.UnsafeChunkEncoders#createNonAllocatingEncoder(int)
+com.ning.compress.lzf.impl.UnsafeChunkEncoders#createEncoder(int, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.impl.UnsafeChunkEncoders#createNonAllocatingEncoder(int, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.impl.UnsafeChunkDecoder#<init>()
+com.ning.compress.lzf.parallel.CompressTask
+com.ning.compress.lzf.util.ChunkEncoderFactory#optimalInstance()
+com.ning.compress.lzf.util.ChunkEncoderFactory#optimalInstance(int)
+com.ning.compress.lzf.util.ChunkEncoderFactory#optimalNonAllocatingInstance(int)
+com.ning.compress.lzf.util.ChunkEncoderFactory#optimalInstance(com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.util.ChunkEncoderFactory#optimalInstance(int, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.util.ChunkEncoderFactory#optimalNonAllocatingInstance(int, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.util.ChunkDecoderFactory#optimalInstance()
+com.ning.compress.lzf.util.LZFFileInputStream#<init>(java.io.File)
+com.ning.compress.lzf.util.LZFFileInputStream#<init>(java.io.FileDescriptor)
+com.ning.compress.lzf.util.LZFFileInputStream#<init>(java.lang.String)
+com.ning.compress.lzf.util.LZFFileOutputStream#<init>(java.io.File)
+com.ning.compress.lzf.util.LZFFileOutputStream#<init>(java.io.File, boolean)
+com.ning.compress.lzf.util.LZFFileOutputStream#<init>(java.io.FileDescriptor)
+com.ning.compress.lzf.util.LZFFileOutputStream#<init>(java.lang.String)
+com.ning.compress.lzf.util.LZFFileOutputStream#<init>(java.lang.String, boolean)
+com.ning.compress.lzf.LZFEncoder#encode(byte[])
+com.ning.compress.lzf.LZFEncoder#encode(byte[], int, int)
+com.ning.compress.lzf.LZFEncoder#encode(byte[], int, int, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.LZFEncoder#appendEncoded(byte[], int, int, byte[], int)
+com.ning.compress.lzf.LZFEncoder#appendEncoded(byte[], int, int, byte[], int, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.LZFCompressingInputStream#<init>(java.io.InputStream)
+com.ning.compress.lzf.LZFDecoder#fastDecoder()
+com.ning.compress.lzf.LZFDecoder#decode(byte[])
+com.ning.compress.lzf.LZFDecoder#decode(byte[], int, int)
+com.ning.compress.lzf.LZFDecoder#decode(byte[], byte[])
+com.ning.compress.lzf.LZFDecoder#decode(byte[], int, int, byte[])
+com.ning.compress.lzf.LZFInputStream#<init>(java.io.InputStream)
+com.ning.compress.lzf.LZFInputStream#<init>(java.io.InputStream, boolean)
+com.ning.compress.lzf.LZFInputStream#<init>(java.io.InputStream, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.LZFInputStream#<init>(java.io.InputStream, com.ning.compress.BufferRecycler, boolean)
+com.ning.compress.lzf.LZFOutputStream#<init>(java.io.OutputStream)
+com.ning.compress.lzf.LZFOutputStream#<init>(java.io.OutputStream, com.ning.compress.BufferRecycler)
+com.ning.compress.lzf.LZFUncompressor#<init>(com.ning.compress.DataHandler)
+com.ning.compress.lzf.LZFUncompressor#<init>(com.ning.compress.DataHandler, com.ning.compress.BufferRecycler)
+
+@defaultMessage Spawns a new thread which is solely under lucenes control use ThreadPool#estimatedTimeInMillisCounter instead
+org.apache.lucene.search.TimeLimitingCollector#getGlobalTimerThread()
+org.apache.lucene.search.TimeLimitingCollector#getGlobalCounter()
+
+@defaultMessage Don't interrupt threads use FutureUtils#cancel(Future<T>) instead
+java.util.concurrent.Future#cancel(boolean)
+
+@defaultMessage Don't try reading from paths that are not configured in Environment, resolve from Environment instead
+org.elasticsearch.common.io.PathUtils#get(java.lang.String, java.lang.String[])
+org.elasticsearch.common.io.PathUtils#get(java.net.URI)

--- a/dev-tools/src/main/resources/forbidden/test-signatures.txt
+++ b/dev-tools/src/main/resources/forbidden/test-signatures.txt
@@ -1,0 +1,20 @@
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance  with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on
+# an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+com.carrotsearch.randomizedtesting.RandomizedTest#globalTempDir() @ Use newTempDirPath() instead
+com.carrotsearch.randomizedtesting.annotations.Seed @ Don't commit hardcoded seeds
+
+org.apache.lucene.codecs.Codec#setDefault(org.apache.lucene.codecs.Codec) @ Use the SuppressCodecs("*") annotation instead

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>dev-tools</artifactId>
+                <version>${elasticsearch.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>1.3</version>
@@ -726,12 +731,6 @@
                 </plugin>
                 <plugin>
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->
-                    <groupId>de.thetaphi</groupId>
-                    <artifactId>forbiddenapis</artifactId>
-                    <version>1.8</version>
-                </plugin>
-                <plugin>
-                    <!-- We just declare which plugin version to use. Each project can have then its own settings -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.5</version>
@@ -939,7 +938,125 @@
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.15</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-remote-resources-plugin</artifactId>
+                    <version>1.5</version>
+                    <configuration>
+                        <resourceBundles>
+                            <resourceBundle>org.elasticsearch:dev-tools:${elasticsearch.version}</resourceBundle>
+                        </resourceBundles>
+                        <outputDirectory>${project.build.directory}/dev-tools</outputDirectory>
+                        <!-- don't include dev-tools in artifacts -->
+                        <attachToMain>false</attachToMain>
+                        <attachToTest>false</attachToTest>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>process</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>de.thetaphi</groupId>
+                    <artifactId>forbiddenapis</artifactId>
+                    <version>1.8</version>
+
+                    <executions>
+                        <execution>
+                            <id>check-forbidden-apis</id>
+                                <configuration>
+                                     <targetVersion>1.7</targetVersion>
+                                     <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                                     <internalRuntimeForbidden>true</internalRuntimeForbidden>
+                                     <!-- if the used Java version is too new, don't fail, just do nothing: -->
+                                     <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                                     <!-- maven shade plugin is a nightmare -->
+                                     <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
+                                     <excludes>
+                                         <exclude>jsr166e/**</exclude>
+                                     </excludes>
+                                     <bundledSignatures>
+                                         <!-- This will automatically choose the right signatures based on 'targetVersion': -->
+                                         <bundledSignature>jdk-unsafe</bundledSignature>
+                                         <bundledSignature>jdk-deprecated</bundledSignature>
+                                         <bundledSignature>jdk-system-out</bundledSignature>
+                                     </bundledSignatures>
+                                     <signaturesFiles>
+                                          <signaturesFile>${project.build.directory}/dev-tools/forbidden/core-signatures.txt</signaturesFile>
+                                          <signaturesFile>${project.build.directory}/dev-tools/forbidden/all-signatures.txt</signaturesFile>
+                                     </signaturesFiles>
+                                     <signatures>${forbidden.signatures}</signatures>
+                                     <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
+                                 </configuration>
+                             <phase>compile</phase>
+                             <goals>
+                                 <goal>check</goal>
+                             </goals>
+                         </execution>
+                         <execution>
+                             <id>check-forbidden-test-apis</id>
+                             <configuration>
+                                 <targetVersion>1.7</targetVersion>
+                                 <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                                 <internalRuntimeForbidden>true</internalRuntimeForbidden>
+                                 <!-- if the used Java version is too new, don't fail, just do nothing: -->
+                                 <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                                 <!-- maven shade plugin is a nightmare -->
+                                 <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
+                                 <bundledSignatures>
+                                     <!-- This will automatically choose the right signatures based on 'targetVersion': -->
+                                     <bundledSignature>jdk-unsafe</bundledSignature>
+                                     <bundledSignature>jdk-deprecated</bundledSignature>
+                                 </bundledSignatures>
+                                 <signaturesFiles>
+                                     <signaturesFile>${project.build.directory}/dev-tools/forbidden/test-signatures.txt</signaturesFile>
+                                     <signaturesFile>${project.build.directory}/dev-tools/forbidden/all-signatures.txt</signaturesFile>
+                                 </signaturesFiles>
+                                 <signatures>${forbidden.test.signatures}</signatures>
+                                 <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
+                             </configuration>
+                             <phase>test-compile</phase>
+                             <goals>
+                                 <goal>testCheck</goal>
+                             </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+    <!-- TODO: add coverage and other static analysis tools, other profiles -->
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+        <profile>
+            <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>de.thetaphi</groupId>
+                        <artifactId>forbiddenapis</artifactId>
+                        <version>1.5.1</version>
+                        <executions>
+                            <execution>
+                                <id>check-forbidden-apis</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>check-forbidden-test-apis</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -451,49 +451,7 @@
     </dependencyManagement>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4</version>
-                    <executions>
-                        <execution>
-                            <id>enforce-versions</id>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                            <configuration>
-                                <rules>
-                                    <requireJavaVersion>
-                                        <version>[1.7,)</version>
-                                    </requireJavaVersion>
-                                </rules>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
+          <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -650,12 +608,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <!-- We just declare which plugin version to use. Each project can have then its own settings -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-                <plugin>
                     <!-- we skip surefire to work with randomized testing above -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -677,6 +629,143 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-remote-resources-plugin</artifactId>
+                    <version>1.5</version>
+                    <configuration>
+                        <resourceBundles>
+                            <resourceBundle>org.elasticsearch:dev-tools:${elasticsearch.version}</resourceBundle>
+                        </resourceBundles>
+                        <outputDirectory>${elasticsearch.tools.directory}</outputDirectory>
+                        <!-- don't include dev-tools in artifacts -->
+                        <attachToMain>false</attachToMain>
+                        <attachToTest>false</attachToTest>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>process</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>de.thetaphi</groupId>
+                    <artifactId>forbiddenapis</artifactId>
+                    <version>1.8</version>
+
+                    <executions>
+                        <execution>
+                            <id>check-forbidden-apis</id>
+                                <configuration>
+                                     <targetVersion>1.7</targetVersion>
+                                     <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                                     <internalRuntimeForbidden>true</internalRuntimeForbidden>
+                                     <!-- if the used Java version is too new, don't fail, just do nothing: -->
+                                     <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                                     <!-- maven shade plugin is a nightmare -->
+                                     <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
+                                     <excludes>
+                                         <exclude>jsr166e/**</exclude>
+                                     </excludes>
+                                     <bundledSignatures>
+                                         <!-- This will automatically choose the right signatures based on 'targetVersion': -->
+                                         <bundledSignature>jdk-unsafe</bundledSignature>
+                                         <bundledSignature>jdk-deprecated</bundledSignature>
+                                         <bundledSignature>jdk-system-out</bundledSignature>
+                                     </bundledSignatures>
+                                     <signaturesFiles>
+                                          <signaturesFile>${elasticsearch.tools.directory}/forbidden/core-signatures.txt</signaturesFile>
+                                          <signaturesFile>${elasticsearch.tools.directory}/forbidden/all-signatures.txt</signaturesFile>
+                                     </signaturesFiles>
+                                     <signatures>${forbidden.signatures}</signatures>
+                                     <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
+                                 </configuration>
+                             <phase>compile</phase>
+                             <goals>
+                                 <goal>check</goal>
+                             </goals>
+                         </execution>
+                         <execution>
+                             <id>check-forbidden-test-apis</id>
+                             <configuration>
+                                 <targetVersion>1.7</targetVersion>
+                                 <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+                                 <internalRuntimeForbidden>true</internalRuntimeForbidden>
+                                 <!-- if the used Java version is too new, don't fail, just do nothing: -->
+                                 <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                                 <!-- maven shade plugin is a nightmare -->
+                                 <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
+                                 <bundledSignatures>
+                                     <!-- This will automatically choose the right signatures based on 'targetVersion': -->
+                                     <bundledSignature>jdk-unsafe</bundledSignature>
+                                     <bundledSignature>jdk-deprecated</bundledSignature>
+                                 </bundledSignatures>
+                                 <signaturesFiles>
+                                     <signaturesFile>${elasticsearch.tools.directory}/forbidden/test-signatures.txt</signaturesFile>
+                                     <signaturesFile>${elasticsearch.tools.directory}/forbidden/all-signatures.txt</signaturesFile>
+                                 </signaturesFiles>
+                                 <signatures>${forbidden.test.signatures}</signatures>
+                                 <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
+                             </configuration>
+                             <phase>test-compile</phase>
+                             <goals>
+                                 <goal>testCheck</goal>
+                             </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.6.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-versions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireJavaVersion>
+                                        <version>[1.7,)</version>
+                                    </requireJavaVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <!-- We just declare which plugin version to use. Each project can have then its own settings -->
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.8</version>
                 </plugin>
                 <plugin>
                     <!-- We just declare which plugin version to use. Each project can have then its own settings -->
@@ -940,93 +1029,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.15</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-remote-resources-plugin</artifactId>
-                    <version>1.5</version>
-                    <configuration>
-                        <resourceBundles>
-                            <resourceBundle>org.elasticsearch:dev-tools:${elasticsearch.version}</resourceBundle>
-                        </resourceBundles>
-                        <outputDirectory>${elasticsearch.tools.directory}</outputDirectory>
-                        <!-- don't include dev-tools in artifacts -->
-                        <attachToMain>false</attachToMain>
-                        <attachToTest>false</attachToTest>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>process</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>de.thetaphi</groupId>
-                    <artifactId>forbiddenapis</artifactId>
-                    <version>1.8</version>
-
-                    <executions>
-                        <execution>
-                            <id>check-forbidden-apis</id>
-                                <configuration>
-                                     <targetVersion>1.7</targetVersion>
-                                     <!-- disallow undocumented classes like sun.misc.Unsafe: -->
-                                     <internalRuntimeForbidden>true</internalRuntimeForbidden>
-                                     <!-- if the used Java version is too new, don't fail, just do nothing: -->
-                                     <failOnUnsupportedJava>false</failOnUnsupportedJava>
-                                     <!-- maven shade plugin is a nightmare -->
-                                     <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
-                                     <excludes>
-                                         <exclude>jsr166e/**</exclude>
-                                     </excludes>
-                                     <bundledSignatures>
-                                         <!-- This will automatically choose the right signatures based on 'targetVersion': -->
-                                         <bundledSignature>jdk-unsafe</bundledSignature>
-                                         <bundledSignature>jdk-deprecated</bundledSignature>
-                                         <bundledSignature>jdk-system-out</bundledSignature>
-                                     </bundledSignatures>
-                                     <signaturesFiles>
-                                          <signaturesFile>${elasticsearch.tools.directory}/forbidden/core-signatures.txt</signaturesFile>
-                                          <signaturesFile>${elasticsearch.tools.directory}/forbidden/all-signatures.txt</signaturesFile>
-                                     </signaturesFiles>
-                                     <signatures>${forbidden.signatures}</signatures>
-                                     <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
-                                 </configuration>
-                             <phase>compile</phase>
-                             <goals>
-                                 <goal>check</goal>
-                             </goals>
-                         </execution>
-                         <execution>
-                             <id>check-forbidden-test-apis</id>
-                             <configuration>
-                                 <targetVersion>1.7</targetVersion>
-                                 <!-- disallow undocumented classes like sun.misc.Unsafe: -->
-                                 <internalRuntimeForbidden>true</internalRuntimeForbidden>
-                                 <!-- if the used Java version is too new, don't fail, just do nothing: -->
-                                 <failOnUnsupportedJava>false</failOnUnsupportedJava>
-                                 <!-- maven shade plugin is a nightmare -->
-                                 <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
-                                 <bundledSignatures>
-                                     <!-- This will automatically choose the right signatures based on 'targetVersion': -->
-                                     <bundledSignature>jdk-unsafe</bundledSignature>
-                                     <bundledSignature>jdk-deprecated</bundledSignature>
-                                 </bundledSignatures>
-                                 <signaturesFiles>
-                                     <signaturesFile>${elasticsearch.tools.directory}/forbidden/test-signatures.txt</signaturesFile>
-                                     <signaturesFile>${elasticsearch.tools.directory}/forbidden/all-signatures.txt</signaturesFile>
-                                 </signaturesFiles>
-                                 <signatures>${forbidden.test.signatures}</signatures>
-                                 <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
-                             </configuration>
-                             <phase>test-compile</phase>
-                             <goals>
-                                 <goal>testCheck</goal>
-                             </goals>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -749,7 +749,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.5.4</version>
                     <configuration>
                         <appendAssemblyId>false</appendAssemblyId>
                         <outputDirectory>${project.build.directory}/releases/</outputDirectory>
@@ -824,12 +824,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.7</version>
-                </plugin>
-                <plugin>
-                    <!-- We just declare which plugin version to use. Each project can have then its own settings -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -748,6 +748,26 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.3</version>
+                    <configuration>
+                        <appendAssemblyId>false</appendAssemblyId>
+                        <outputDirectory>${project.build.directory}/releases/</outputDirectory>
+                        <descriptors>
+                            <descriptor>${basedir}/src/main/assemblies/plugin.xml</descriptor>
+                        </descriptors>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>2.6.1</version>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,9 @@
         <slf4j.version>1.6.2</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
 
+        <!-- Build resources properties -->
+        <elasticsearch.tools.directory>${project.build.directory}/dev-tools</elasticsearch.tools.directory>
+
         <!-- Test properties -->
         <tests.jvms>auto</tests.jvms>
         <java.permGenSpace>-XX:MaxPermSize=128m</java.permGenSpace>
@@ -946,7 +949,7 @@
                         <resourceBundles>
                             <resourceBundle>org.elasticsearch:dev-tools:${elasticsearch.version}</resourceBundle>
                         </resourceBundles>
-                        <outputDirectory>${project.build.directory}/dev-tools</outputDirectory>
+                        <outputDirectory>${elasticsearch.tools.directory}</outputDirectory>
                         <!-- don't include dev-tools in artifacts -->
                         <attachToMain>false</attachToMain>
                         <attachToTest>false</attachToTest>
@@ -985,8 +988,8 @@
                                          <bundledSignature>jdk-system-out</bundledSignature>
                                      </bundledSignatures>
                                      <signaturesFiles>
-                                          <signaturesFile>${project.build.directory}/dev-tools/forbidden/core-signatures.txt</signaturesFile>
-                                          <signaturesFile>${project.build.directory}/dev-tools/forbidden/all-signatures.txt</signaturesFile>
+                                          <signaturesFile>${elasticsearch.tools.directory}/forbidden/core-signatures.txt</signaturesFile>
+                                          <signaturesFile>${elasticsearch.tools.directory}/forbidden/all-signatures.txt</signaturesFile>
                                      </signaturesFiles>
                                      <signatures>${forbidden.signatures}</signatures>
                                      <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>
@@ -1012,8 +1015,8 @@
                                      <bundledSignature>jdk-deprecated</bundledSignature>
                                  </bundledSignatures>
                                  <signaturesFiles>
-                                     <signaturesFile>${project.build.directory}/dev-tools/forbidden/test-signatures.txt</signaturesFile>
-                                     <signaturesFile>${project.build.directory}/dev-tools/forbidden/all-signatures.txt</signaturesFile>
+                                     <signaturesFile>${elasticsearch.tools.directory}/forbidden/test-signatures.txt</signaturesFile>
+                                     <signaturesFile>${elasticsearch.tools.directory}/forbidden/all-signatures.txt</signaturesFile>
                                  </signaturesFiles>
                                  <signatures>${forbidden.test.signatures}</signatures>
                                  <suppressAnnotations><annotation>**.SuppressForbidden</annotation></suppressAnnotations>

--- a/pom.xml
+++ b/pom.xml
@@ -1046,7 +1046,6 @@
                     <plugin>
                         <groupId>de.thetaphi</groupId>
                         <artifactId>forbiddenapis</artifactId>
-                        <version>1.5.1</version>
                         <executions>
                             <execution>
                                 <id>check-forbidden-apis</id>

--- a/pom.xml
+++ b/pom.xml
@@ -471,8 +471,15 @@
               </testResource>
               <testResource>
                   <directory>src/test/resources</directory>
+                  <excludes>
+                      <exclude>elasticsearch.yml</exclude>
+                  </excludes>
+              </testResource>
+              <testResource>
+                  <directory>src/test/resources</directory>
+                  <filtering>true</filtering>
                   <includes>
-                      <include>**/*.*</include>
+                      <include>elasticsearch.yml</include>
                   </includes>
               </testResource>
           </testResources>

--- a/pom.xml
+++ b/pom.xml
@@ -1059,4 +1059,7 @@
             </build>
         </profile>
     </profiles>
+    <modules>
+        <module>dev-tools</module>
+    </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,32 @@
     </dependencyManagement>
 
     <build>
+          <resources>
+              <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>true</filtering>
+                  <includes>
+                      <include>**/*.properties</include>
+                  </includes>
+              </resource>
+          </resources>
+
+          <testResources>
+              <testResource>
+                  <directory>src/test/java</directory>
+                  <includes>
+                      <include>**/*.json</include>
+                      <include>**/*.txt</include>
+                  </includes>
+              </testResource>
+              <testResource>
+                  <directory>src/test/resources</directory>
+                  <includes>
+                      <include>**/*.*</include>
+                  </includes>
+              </testResource>
+          </testResources>
+
           <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This makes `dev-tools` a little module that other modules
pull with maven-remote-resources plugin. This way we can include
PMD configuration, whatever we need. Entirety of dev-tools soon...

I added the forbidden API configuration from es-core. Plugins don't
need to do the path based exceptions in POM files, these days just
use the `@SuppressForbidden(reason = ...)` mechanism via annotations
for exceptions.

I also added 'dev' profile, since it kinda goes along with forbidden-apis,
its a way to skip the check.

I tested this with kuromoji plugin, everything works easily with just these
additions to its POM:

    <plugin>
      <groupId>org.apache.maven.plugins</groupId>
      <artifactId>maven-remote-resources-plugin</artifactId>
    </plugin>
    <plugin>
      <groupId>de.thetaphi</groupId>
      <artifactId>forbiddenapis</artifactId>
    </plugin>

Closes #42