### PR TITLE
[maven] use parent dir for dev-tools directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <log4j.version>1.2.17</log4j.version>
 
         <!-- Build resources properties -->
-        <elasticsearch.tools.directory>${project.build.directory}/dev-tools</elasticsearch.tools.directory>
+        <elasticsearch.tools.directory>${project.parent.build.directory}/dev-tools</elasticsearch.tools.directory>
         <elasticsearch.thirdparty.config>shaded</elasticsearch.thirdparty.config>
         <elasticsearch.license.header>${elasticsearch.tools.directory}/license-check/elasticsearch_license_header.txt</elasticsearch.license.header>
         <elasticsearch.license.headerDefinition>${elasticsearch.tools.directory}/license-check/license_header_definition.xml</elasticsearch.license.headerDefinition>


### PR DESCRIPTION
When using `dev-tools` in a sub project, maven can not find the `dev-tools` dir inside the sub module it self.

To fix that, we need to set that `elasticsearch.tools.directory` is actually using the parent dir.

``` xml
<elasticsearch.tools.directory>${project.parent.build.directory}/dev-tools</elasticsearch.tools.directory>
```

Note that the issue could still appear if you are defining a sub module of the first module.

`parent->plugins->myplugin` might not be able to find it.

A workaround could be to keep `${project.build.directory}` in parent project.
But define in plugins `pom.xml` `${project.parent.build.directory}` and in myplugin `pom.xml` `${project.parent.parent.build.directory}`.

@rmuir WDYT?
